### PR TITLE
GA 플러그인 gtag로 교체

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -68,9 +68,12 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-plugin-google-analytics`,
+      resolve: `gatsby-plugin-google-gtag`,
       options: {
-        trackingId: metaConfig.ga,
+        trackingIds: [metaConfig.ga, 'G-VZ19ZNF3YQ'],
+        pluginConfig: {
+          head: true,
+        },
       },
     },
     {
@@ -115,15 +118,15 @@ module.exports = {
         feeds: [
           {
             serialize: ({ query: { site, allMarkdownRemark } }) => {
-              return allMarkdownRemark.edges.map((edge) => {
+              return allMarkdownRemark.edges.map(edge => {
                 return Object.assign({}, edge.node.frontmatter, {
                   description: edge.node.excerpt,
                   date: edge.node.frontmatter.date,
                   url: site.siteMetadata.siteUrl + edge.node.fields.slug,
                   guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
-                  custom_elements: [{ "content:encoded": edge.node.html }],
-                })
-              })
+                  custom_elements: [{ 'content:encoded': edge.node.html }],
+                });
+              });
             },
             query: `
               {
@@ -145,7 +148,7 @@ module.exports = {
                 }
               }
             `,
-            output: "/rss.xml",
+            output: '/rss.xml',
           },
         ],
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11322,13 +11322,36 @@
         "@babel/runtime": "^7.2.0"
       }
     },
-    "gatsby-plugin-google-analytics": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.2.2.tgz",
-      "integrity": "sha512-at0eUPTyetGuPW1ceISAv58a9fwbwsLX9V5ucwKYShs98Spil/FWviukW0f1A2LUsWOGTiVJYReS7IVVw+FlIA==",
+    "gatsby-plugin-google-gtag": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-5.9.0.tgz",
+      "integrity": "sha512-BJJHBgcbsmOuDJEN2aGarEWxaxw1rf8qLRllv2rbJbCHR/asmr7WWLspLWesqrDtSFJKdHYHA9c0I98fUWFeOw==",
       "requires": {
-        "@babel/runtime": "^7.8.7",
-        "minimatch": "3.0.4"
+        "@babel/runtime": "^7.20.13",
+        "minimatch": "^3.1.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.21.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+          "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.11"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.11",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+          "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+        }
       }
     },
     "gatsby-plugin-lodash": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gatsby-image": "^2.0.34",
     "gatsby-plugin-feed": "^2.1.0",
     "gatsby-plugin-google-adsense": "^1.1.3",
-    "gatsby-plugin-google-analytics": "^2.0.17",
+    "gatsby-plugin-google-gtag": "^5.9.0",
     "gatsby-plugin-lodash": "^3.0.5",
     "gatsby-plugin-manifest": "^2.0.24",
     "gatsby-plugin-offline": "^2.0.25",


### PR DESCRIPTION
- GA4 지원을 위해 `gatsby-plugin-google-analytics`에서 `gatsby-plugin-google-gtag`로 플러그인 교체