### PR TITLE
[codex] Add post search

### DIFF
--- a/src/components/contents/index.jsx
+++ b/src/components/contents/index.jsx
@@ -3,23 +3,36 @@ import React, { useMemo } from 'react'
 import { ThumbnailContainer } from '../thumbnail-container'
 import { ThumbnailItem } from '../thumbnail-item'
 import { CATEGORY_TYPE } from '../../constants'
+import { filterPostsBySearch } from '../../utils/post-search'
 
-export const Contents = ({ posts, countOfInitialPost, count, category }) => {
-  const refinedPosts = useMemo(() =>
-    posts
-      .filter(
-        ({ node }) =>
-          category === CATEGORY_TYPE.ALL ||
-          node.frontmatter.category === category
-      )
-      .slice(0, count * countOfInitialPost)
+export const Contents = ({
+  posts,
+  countOfInitialPost,
+  count,
+  category,
+  searchQuery,
+}) => {
+  const refinedPosts = useMemo(
+    () =>
+      filterPostsBySearch(posts, searchQuery)
+        .filter(
+          ({ node }) =>
+            category === CATEGORY_TYPE.ALL ||
+            node.frontmatter.category === category
+        )
+        .slice(0, count * countOfInitialPost),
+    [posts, searchQuery, category, count, countOfInitialPost]
   )
 
   return (
     <ThumbnailContainer>
-      {refinedPosts.map(({ node }, index) => (
-        <ThumbnailItem node={node} key={`item_${index}`} />
-      ))}
+      {refinedPosts.length === 0 ? (
+        <p className="post-search__empty">No posts found.</p>
+      ) : (
+        refinedPosts.map(({ node }, index) => (
+          <ThumbnailItem node={node} key={`item_${index}`} />
+        ))
+      )}
     </ThumbnailContainer>
   )
 }

--- a/src/components/post-search/index.jsx
+++ b/src/components/post-search/index.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import './index.scss'
+
+export const PostSearch = ({ searchQuery, onSearch }) => (
+  <form className="post-search" role="search" onSubmit={event => event.preventDefault()}>
+    <label className="post-search__label" htmlFor="post-search">
+      Search
+    </label>
+    <div className="post-search__control">
+      <input
+        id="post-search"
+        className="post-search__input"
+        type="search"
+        value={searchQuery}
+        onChange={event => onSearch(event.target.value)}
+        placeholder="Search posts"
+        autoComplete="off"
+      />
+      {searchQuery && (
+        <button
+          className="post-search__clear"
+          type="button"
+          aria-label="Clear search"
+          onClick={() => onSearch('')}
+        >
+          x
+        </button>
+      )}
+    </div>
+  </form>
+)

--- a/src/components/post-search/index.jsx
+++ b/src/components/post-search/index.jsx
@@ -3,9 +3,13 @@ import React from 'react'
 import './index.scss'
 
 export const PostSearch = ({ searchQuery, onSearch }) => (
-  <form className="post-search" role="search" onSubmit={event => event.preventDefault()}>
+  <form
+    className="post-search"
+    role="search"
+    onSubmit={event => event.preventDefault()}
+  >
     <label className="post-search__label" htmlFor="post-search">
-      Search
+      포스트 검색
     </label>
     <div className="post-search__control">
       <input
@@ -14,7 +18,7 @@ export const PostSearch = ({ searchQuery, onSearch }) => (
         type="search"
         value={searchQuery}
         onChange={event => onSearch(event.target.value)}
-        placeholder="Search posts"
+        placeholder="포스트 검색하기"
         autoComplete="off"
       />
       {searchQuery && (
@@ -24,7 +28,7 @@ export const PostSearch = ({ searchQuery, onSearch }) => (
           aria-label="Clear search"
           onClick={() => onSearch('')}
         >
-          x
+          <span aria-hidden="true">×</span>
         </button>
       )}
     </div>

--- a/src/components/post-search/index.scss
+++ b/src/components/post-search/index.scss
@@ -1,14 +1,17 @@
 .post-search {
-  margin: 0 0 0.75rem;
+  margin: 0 0 0.85rem;
 }
 
 .post-search__label {
-  display: block;
-  margin-bottom: 0.35rem;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .post-search__control {
@@ -17,33 +20,50 @@
 
 .post-search__input {
   width: 100%;
-  height: 44px;
-  padding: 0 42px 0 14px;
-  border-radius: 8px;
+  height: 48px;
+  padding: 0 48px 0 18px;
+  border-radius: 12px;
   border: 1px solid;
   box-sizing: border-box;
-  font-size: 15px;
+  font-size: 16px;
   outline: none;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease,
+    background-color 0.15s ease;
 }
 
 .post-search__input:focus {
-  box-shadow: 0 0 0 3px rgba(0, 105, 255, 0.14);
+  box-shadow: 0 0 0 4px rgba(0, 105, 255, 0.13);
 }
 
 .post-search__clear {
   position: absolute;
   top: 50%;
-  right: 10px;
-  width: 28px;
-  height: 28px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
   padding: 0;
-  border: 0;
+  border: 1px solid;
   border-radius: 50%;
   cursor: pointer;
   font-size: 16px;
-  line-height: 28px;
+  font-weight: 700;
+  line-height: 1;
   transform: translateY(-50%);
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+    color 0.15s ease, transform 0.15s ease;
+}
+
+.post-search__clear:hover,
+.post-search__clear:focus {
+  transform: translateY(-50%) scale(1.04);
+}
+
+.post-search__clear:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0, 105, 255, 0.13);
 }
 
 .post-search__empty {

--- a/src/components/post-search/index.scss
+++ b/src/components/post-search/index.scss
@@ -1,0 +1,53 @@
+.post-search {
+  margin: 0 0 0.75rem;
+}
+
+.post-search__label {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.post-search__control {
+  position: relative;
+}
+
+.post-search__input {
+  width: 100%;
+  height: 44px;
+  padding: 0 42px 0 14px;
+  border-radius: 8px;
+  border: 1px solid;
+  box-sizing: border-box;
+  font-size: 15px;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.post-search__input:focus {
+  box-shadow: 0 0 0 3px rgba(0, 105, 255, 0.14);
+}
+
+.post-search__clear {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 28px;
+  transform: translateY(-50%);
+}
+
+.post-search__empty {
+  margin: 2rem 0;
+  font-size: 0.9rem;
+  text-align: center;
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,6 +7,7 @@ import { Bio } from '../components/bio'
 import { Seo } from '../components/head'
 import { Category } from '../components/category'
 import { Contents } from '../components/contents'
+import { PostSearch } from '../components/post-search'
 
 import * as ScrollManager from '../utils/scroll'
 import * as Storage from '../utils/storage'
@@ -29,6 +30,7 @@ export default ({ data, location }) => {
   const [count, setCount] = useState(initialCount)
   const countRef = useRef(count)
   const [category, setCategory] = useState(initialCategory)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const { siteMetadata } = data.site
   const { countOfInitialPost } = siteMetadata.configs
@@ -56,7 +58,13 @@ export default ({ data, location }) => {
 
   const selectCategory = category => {
     setCategory(category)
+    setCount(1)
     ScrollManager.go(DEST_POS)
+  }
+
+  const searchPosts = searchQuery => {
+    setSearchQuery(searchQuery)
+    setCount(1)
   }
 
   const onScroll = () => {
@@ -74,6 +82,7 @@ export default ({ data, location }) => {
   return (
     <Layout location={location} title={siteMetadata.title}>
       <Bio />
+      <PostSearch searchQuery={searchQuery} onSearch={searchPosts} />
       <Category
         categories={categories}
         category={category}
@@ -84,6 +93,7 @@ export default ({ data, location }) => {
         countOfInitialPost={countOfInitialPost}
         count={count}
         category={category}
+        searchQuery={searchQuery}
       />
     </Layout>
   )

--- a/src/styles/dark-theme.scss
+++ b/src/styles/dark-theme.scss
@@ -46,7 +46,6 @@ body.dark {
     }
   }
 
-  .post-search__label,
   .post-search__empty {
     color: $dark-middle-font-color;
   }
@@ -55,6 +54,7 @@ body.dark {
     background-color: $dark-category-item-color;
     border-color: $dark-category-border-color;
     color: $dark-light-font-color;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.24);
 
     &::placeholder {
       color: $dark-middle-font-color;
@@ -67,7 +67,15 @@ body.dark {
 
   .post-search__clear {
     background-color: $dark-category-background-color;
+    border-color: $dark-category-border-color;
     color: $dark-middle-font-color;
+
+    &:hover,
+    &:focus {
+      background-color: $dark-category-item-color;
+      border-color: $dark-category-highlight-border-color;
+      color: $dark-lightest-font-color;
+    }
   }
 
   .thumbnail {

--- a/src/styles/dark-theme.scss
+++ b/src/styles/dark-theme.scss
@@ -46,6 +46,30 @@ body.dark {
     }
   }
 
+  .post-search__label,
+  .post-search__empty {
+    color: $dark-middle-font-color;
+  }
+
+  .post-search__input {
+    background-color: $dark-category-item-color;
+    border-color: $dark-category-border-color;
+    color: $dark-light-font-color;
+
+    &::placeholder {
+      color: $dark-middle-font-color;
+    }
+
+    &:focus {
+      border-color: $dark-category-highlight-border-color;
+    }
+  }
+
+  .post-search__clear {
+    background-color: $dark-category-background-color;
+    color: $dark-middle-font-color;
+  }
+
   .thumbnail {
     h3 {
       color: $dark-light-font-color;

--- a/src/styles/light-theme.scss
+++ b/src/styles/light-theme.scss
@@ -45,7 +45,6 @@ body.light {
     }
   }
 
-  .post-search__label,
   .post-search__empty {
     color: $middle-gray;
   }
@@ -54,6 +53,7 @@ body.light {
     background-color: $light-category-item-color;
     border-color: $light-category-border-color;
     color: $dark-gray;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 
     &::placeholder {
       color: $middle-gray;
@@ -65,8 +65,16 @@ body.light {
   }
 
   .post-search__clear {
-    background-color: $light-category-background-color;
+    background-color: #fff;
+    border-color: $light-category-border-color;
     color: $middle-gray;
+
+    &:hover,
+    &:focus {
+      background-color: $light-category-background-color;
+      border-color: $light-category-highlight-border-color;
+      color: $dark-gray;
+    }
   }
 
   .thumbnail {

--- a/src/styles/light-theme.scss
+++ b/src/styles/light-theme.scss
@@ -45,6 +45,30 @@ body.light {
     }
   }
 
+  .post-search__label,
+  .post-search__empty {
+    color: $middle-gray;
+  }
+
+  .post-search__input {
+    background-color: $light-category-item-color;
+    border-color: $light-category-border-color;
+    color: $dark-gray;
+
+    &::placeholder {
+      color: $middle-gray;
+    }
+
+    &:focus {
+      border-color: $light-category-highlight-border-color;
+    }
+  }
+
+  .post-search__clear {
+    background-color: $light-category-background-color;
+    color: $middle-gray;
+  }
+
   .thumbnail {
     h3 {
       color: $dark-gray;

--- a/src/utils/post-search.js
+++ b/src/utils/post-search.js
@@ -1,0 +1,28 @@
+const normalizeSearchText = value =>
+  String(value || '')
+    .trim()
+    .toLowerCase()
+
+const getSearchableText = post => {
+  const node = post && post.node ? post.node : {}
+  const frontmatter = node.frontmatter || {}
+
+  return normalizeSearchText(
+    [frontmatter.title, node.excerpt, frontmatter.category].join(' ')
+  )
+}
+
+const filterPostsBySearch = (posts, searchQuery) => {
+  const normalizedQuery = normalizeSearchText(searchQuery)
+
+  if (!normalizedQuery) {
+    return posts
+  }
+
+  return posts.filter(post => getSearchableText(post).includes(normalizedQuery))
+}
+
+module.exports = {
+  filterPostsBySearch,
+  normalizeSearchText,
+}

--- a/src/utils/post-search.test.js
+++ b/src/utils/post-search.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { filterPostsBySearch } = require('./post-search')
+
+const posts = [
+  {
+    node: {
+      excerpt: 'React rendering and state management notes',
+      frontmatter: {
+        title: 'React Hooks Guide',
+        category: 'react',
+      },
+    },
+  },
+  {
+    node: {
+      excerpt: 'Practical static site generation with Gatsby',
+      frontmatter: {
+        title: 'Building a Blog',
+        category: 'web',
+      },
+    },
+  },
+]
+
+test('returns every post when search query is blank', () => {
+  assert.deepEqual(filterPostsBySearch(posts, '   '), posts)
+})
+
+test('matches posts by title, excerpt, and category', () => {
+  assert.equal(filterPostsBySearch(posts, 'hooks').length, 1)
+  assert.equal(filterPostsBySearch(posts, 'static site')[0], posts[1])
+  assert.equal(filterPostsBySearch(posts, 'WEB')[0], posts[1])
+})
+
+test('returns no posts when the query does not match searchable fields', () => {
+  assert.deepEqual(filterPostsBySearch(posts, 'typescript'), [])
+})


### PR DESCRIPTION
## Summary
- Add a search input above the category selector on the home page.
- Filter posts by title, excerpt, and category while preserving the existing category filter and pagination behavior.
- Add a small pure search utility with Node tests, plus light/dark theme styling and an empty result state.

## Validation
- `node --test src/utils/post-search.test.js`
- `npm run lint`
- `npm run build`
- Browser QA on `http://localhost:8000/` for default, filtered, empty, and mobile states

## Notes
- Local `git push` over HTTPS was blocked by missing git credentials, so the remote branch was created through the GitHub connector from the same tree as the local commit.