### PR TITLE
[codex] Enhance post search experience

### DIFF
--- a/src/components/contents/index.jsx
+++ b/src/components/contents/index.jsx
@@ -3,7 +3,10 @@ import React, { useMemo } from 'react'
 import { ThumbnailContainer } from '../thumbnail-container'
 import { ThumbnailItem } from '../thumbnail-item'
 import { CATEGORY_TYPE } from '../../constants'
-import { filterPostsBySearch } from '../../utils/post-search'
+import {
+  filterPostsBySearch,
+  getSearchSummaryText,
+} from '../../utils/post-search'
 
 export const Contents = ({
   posts,
@@ -12,27 +15,35 @@ export const Contents = ({
   category,
   searchQuery,
 }) => {
-  const refinedPosts = useMemo(
+  const filteredPosts = useMemo(
     () =>
-      filterPostsBySearch(posts, searchQuery)
-        .filter(
-          ({ node }) =>
-            category === CATEGORY_TYPE.ALL ||
-            node.frontmatter.category === category
-        )
-        .slice(0, count * countOfInitialPost),
-    [posts, searchQuery, category, count, countOfInitialPost]
+      filterPostsBySearch(posts, searchQuery).filter(
+        ({ node }) =>
+          category === CATEGORY_TYPE.ALL ||
+          node.frontmatter.category === category
+      ),
+    [posts, searchQuery, category]
   )
+  const refinedPosts = filteredPosts.slice(0, count * countOfInitialPost)
 
   return (
-    <ThumbnailContainer>
-      {refinedPosts.length === 0 ? (
-        <p className="post-search__empty">No posts found.</p>
-      ) : (
-        refinedPosts.map(({ node }, index) => (
-          <ThumbnailItem node={node} key={`item_${index}`} />
-        ))
-      )}
-    </ThumbnailContainer>
+    <>
+      <p className="post-search__summary">
+        {getSearchSummaryText(filteredPosts.length, category, searchQuery)}
+      </p>
+      <ThumbnailContainer>
+        {refinedPosts.length === 0 ? (
+          <p className="post-search__empty">검색 결과가 없습니다.</p>
+        ) : (
+          refinedPosts.map(({ node }, index) => (
+            <ThumbnailItem
+              node={node}
+              searchQuery={searchQuery}
+              key={`item_${index}`}
+            />
+          ))
+        )}
+      </ThumbnailContainer>
+    </>
   )
 }

--- a/src/components/post-search/index.jsx
+++ b/src/components/post-search/index.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import './index.scss'
 
-export const PostSearch = ({ searchQuery, onSearch }) => (
+export const PostSearch = ({ searchQuery, onSearch, inputRef }) => (
   <form
     className="post-search"
     role="search"
@@ -13,6 +13,7 @@ export const PostSearch = ({ searchQuery, onSearch }) => (
     </label>
     <div className="post-search__control">
       <input
+        ref={inputRef}
         id="post-search"
         className="post-search__input"
         type="search"

--- a/src/components/post-search/index.scss
+++ b/src/components/post-search/index.scss
@@ -71,3 +71,16 @@
   font-size: 0.9rem;
   text-align: center;
 }
+
+.post-search__summary {
+  margin: 0.85rem 0 1rem;
+  font-size: 0.84rem;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.post-search-highlight {
+  padding: 0 0.12em;
+  border-radius: 3px;
+  color: inherit;
+}

--- a/src/components/thumbnail-item/index.jsx
+++ b/src/components/thumbnail-item/index.jsx
@@ -1,15 +1,27 @@
 import React from 'react'
 import { Link } from 'gatsby'
 import { TARGET_CLASS } from '../../utils/visible'
+import { highlightSearchText } from '../../utils/post-search'
 
 import './index.scss'
 
-export const ThumbnailItem = ({ node }) => (
+export const ThumbnailItem = ({ node, searchQuery }) => (
   <Link className={`thumbnail ${TARGET_CLASS}`} to={node.fields.slug}>
     <div key={node.fields.slug}>
-      <h3>{node.frontmatter.title || node.fields.slug}</h3>
+      <h3
+        dangerouslySetInnerHTML={{
+          __html: highlightSearchText(
+            node.frontmatter.title || node.fields.slug,
+            searchQuery
+          ),
+        }}
+      />
       <small>{new Date(node.frontmatter.date).toLocaleDateString()}</small>
-      <p dangerouslySetInnerHTML={{ __html: node.excerpt }} />
+      <p
+        dangerouslySetInnerHTML={{
+          __html: highlightSearchText(node.excerpt, searchQuery),
+        }}
+      />
     </div>
   </Link>
 )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -29,8 +29,12 @@ export default ({ data, location }) => {
   const initialCategory = Storage.getCategory(CATEGORY_TYPE.ALL)
   const [count, setCount] = useState(initialCount)
   const countRef = useRef(count)
+  const searchInputRef = useRef(null)
   const [category, setCategory] = useState(initialCategory)
-  const [searchQuery, setSearchQuery] = useState('')
+  const [searchQuery, setSearchQuery] = useState(() => {
+    const params = new URLSearchParams(location.search)
+    return params.get('q') || ''
+  })
 
   const { siteMetadata } = data.site
   const { countOfInitialPost } = siteMetadata.configs
@@ -55,6 +59,50 @@ export default ({ data, location }) => {
     Storage.setCount(count)
     Storage.setCategory(category)
   })
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+
+    if (searchQuery) {
+      params.set('q', searchQuery)
+    } else {
+      params.delete('q')
+    }
+
+    const nextSearch = params.toString()
+    const nextUrl = nextSearch
+      ? `${window.location.pathname}?${nextSearch}`
+      : window.location.pathname
+
+    window.history.replaceState(null, '', nextUrl)
+  }, [searchQuery])
+
+  useEffect(() => {
+    const onKeyDown = event => {
+      const target = event.target
+      const isInputTarget =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target.isContentEditable
+
+      if (event.key === '/' && !event.metaKey && !event.ctrlKey && !isInputTarget) {
+        event.preventDefault()
+        searchInputRef.current.focus()
+        return
+      }
+
+      if (event.key === 'Escape' && searchQuery) {
+        event.preventDefault()
+        searchPosts('')
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [searchQuery])
 
   const selectCategory = category => {
     setCategory(category)
@@ -82,7 +130,11 @@ export default ({ data, location }) => {
   return (
     <Layout location={location} title={siteMetadata.title}>
       <Bio />
-      <PostSearch searchQuery={searchQuery} onSearch={searchPosts} />
+      <PostSearch
+        searchQuery={searchQuery}
+        onSearch={searchPosts}
+        inputRef={searchInputRef}
+      />
       <Category
         categories={categories}
         category={category}

--- a/src/styles/dark-theme.scss
+++ b/src/styles/dark-theme.scss
@@ -46,8 +46,13 @@ body.dark {
     }
   }
 
-  .post-search__empty {
+  .post-search__empty,
+  .post-search__summary {
     color: $dark-middle-font-color;
+  }
+
+  .post-search-highlight {
+    background-color: rgba(255, 218, 76, 0.32);
   }
 
   .post-search__input {

--- a/src/styles/light-theme.scss
+++ b/src/styles/light-theme.scss
@@ -45,8 +45,13 @@ body.light {
     }
   }
 
-  .post-search__empty {
+  .post-search__empty,
+  .post-search__summary {
     color: $middle-gray;
+  }
+
+  .post-search-highlight {
+    background-color: rgba(255, 229, 64, 0.55);
   }
 
   .post-search__input {

--- a/src/utils/post-search.js
+++ b/src/utils/post-search.js
@@ -3,6 +3,16 @@ const normalizeSearchText = value =>
     .trim()
     .toLowerCase()
 
+const escapeHtml = value =>
+  String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 const getSearchableText = post => {
   const node = post && post.node ? post.node : {}
   const frontmatter = node.frontmatter || {}
@@ -22,7 +32,52 @@ const filterPostsBySearch = (posts, searchQuery) => {
   return posts.filter(post => getSearchableText(post).includes(normalizedQuery))
 }
 
+const highlightSearchText = (value, searchQuery) => {
+  const text = String(value || '')
+  const normalizedQuery = normalizeSearchText(searchQuery)
+
+  if (!normalizedQuery) {
+    return escapeHtml(text)
+  }
+
+  const matcher = new RegExp(`(${escapeRegExp(normalizedQuery)})`, 'gi')
+
+  return text
+    .split(matcher)
+    .map(part => {
+      const escapedPart = escapeHtml(part)
+
+      if (normalizeSearchText(part) === normalizedQuery) {
+        return `<mark class="post-search-highlight">${escapedPart}</mark>`
+      }
+
+      return escapedPart
+    })
+    .join('')
+}
+
+const getSearchSummaryText = (resultCount, category, searchQuery) => {
+  const normalizedQuery = String(searchQuery || '').trim()
+  const isAllCategory = category === 'All'
+
+  if (normalizedQuery && !isAllCategory) {
+    return `${category} 카테고리에서 "${normalizedQuery}" 검색 중 · ${resultCount}개`
+  }
+
+  if (normalizedQuery) {
+    return `"${normalizedQuery}" 검색 결과 ${resultCount}개`
+  }
+
+  if (!isAllCategory) {
+    return `${category} 카테고리 포스트 ${resultCount}개`
+  }
+
+  return `전체 포스트 ${resultCount}개`
+}
+
 module.exports = {
   filterPostsBySearch,
+  getSearchSummaryText,
+  highlightSearchText,
   normalizeSearchText,
 }

--- a/src/utils/post-search.test.js
+++ b/src/utils/post-search.test.js
@@ -1,7 +1,11 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
 
-const { filterPostsBySearch } = require('./post-search')
+const {
+  filterPostsBySearch,
+  getSearchSummaryText,
+  highlightSearchText,
+} = require('./post-search')
 
 const posts = [
   {
@@ -36,4 +40,25 @@ test('matches posts by title, excerpt, and category', () => {
 
 test('returns no posts when the query does not match searchable fields', () => {
   assert.deepEqual(filterPostsBySearch(posts, 'typescript'), [])
+})
+
+test('wraps matched search text while escaping source HTML', () => {
+  assert.equal(
+    highlightSearchText('React <Hooks> & State', 'hook'),
+    'React &lt;<mark class="post-search-highlight">Hook</mark>s&gt; &amp; State'
+  )
+})
+
+test('leaves text escaped without highlights when search query is blank', () => {
+  assert.equal(highlightSearchText('<React>', ''), '&lt;React&gt;')
+})
+
+test('builds result summary text for category and search state', () => {
+  assert.equal(getSearchSummaryText(12, 'All', ''), '전체 포스트 12개')
+  assert.equal(
+    getSearchSummaryText(3, 'React', 'hooks'),
+    'React 카테고리에서 "hooks" 검색 중 · 3개'
+  )
+  assert.equal(getSearchSummaryText(2, 'All', 'react'), '"react" 검색 결과 2개')
+  assert.equal(getSearchSummaryText(5, 'Web', ''), 'Web 카테고리 포스트 5개')
 })


### PR DESCRIPTION
## Summary
- Highlight matched search terms in post titles and excerpts.
- Show result count/status text for search and category combinations.
- Preserve search state in the URL with `?q=`.
- Add keyboard shortcuts: `/` focuses search and `Esc` clears the current query.
- Localize the empty-result message to Korean.

## Validation
- `node --test src/utils/post-search.test.js`
- `npm run lint`
- `npm run build`
- Browser QA on `http://localhost:8000/?q=react` for URL query restore, highlight rendering, category/search status text, `Esc` clear, and `/` focus

## Notes
- This follows up on the already-merged post search PR #144.