### PR TITLE
[codex] Clean up blog warnings and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -145,6 +145,7 @@ module.exports = {
         ],
       },
     },
+    `gatsby-plugin-image`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     `gatsby-plugin-offline`,

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "scripts": {
     "post": "gatsby-post-gen",
     "dev": "gatsby develop",
+    "test": "node --test src/**/*.test.js",
     "lint": "eslint --ext .js,.jsx --ignore-pattern public .",
     "format": "prettier --trailing-comma es5 --no-semi --single-quote --write 'src/**/*.js' 'src/**/*.md'",
     "develop": "gatsby develop",

--- a/src/components/bio/index.jsx
+++ b/src/components/bio/index.jsx
@@ -1,74 +1,68 @@
 import React from 'react';
-import { StaticQuery, graphql, Link } from 'gatsby';
+import { graphql, Link, useStaticQuery } from 'gatsby';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 
 import './index.scss';
 
-export const Bio = () => (
-  <StaticQuery
-    query={bioQuery}
-    render={data => {
-      const { author, social, introduction } = data.site.siteMetadata;
+export const Bio = () => {
+  const data = useStaticQuery(bioQuery);
+  const { author, social, introduction } = data.site.siteMetadata;
 
-      return (
-        <div className="bio">
-          <div className="author">
-            <div className="author-description">
-              <GatsbyImage
-                className="author-image"
-                image={getImage(data.avatar)}
-                alt={author}
-                style={{
-                  borderRadius: `100%`,
-                }}
-              />
-              <div className="author-name">
-                <span className="author-name-prefix">Written by</span>
-                <a
-                  href={
-                    'https://ykss.notion.site/Kyeongsang-Yu-a4ddc1935ee74a0aafbb311aa7f675e7'
-                  }
-                  className="author-name-content"
-                >
-                  <span>@{author}</span>
+  return (
+    <div className="bio">
+      <div className="author">
+        <div className="author-description">
+          <GatsbyImage
+            className="author-image"
+            image={getImage(data.avatar)}
+            alt={author}
+            style={{
+              borderRadius: `100%`,
+            }}
+          />
+          <div className="author-name">
+            <span className="author-name-prefix">Written by</span>
+            <a
+              href={
+                'https://ykss.notion.site/Kyeongsang-Yu-a4ddc1935ee74a0aafbb311aa7f675e7'
+              }
+              className="author-name-content"
+            >
+              <span>@{author}</span>
+            </a>
+            <div className="author-introduction">{introduction}</div>
+            <p className="author-socials">
+              {social.github && (
+                <a href={`https://github.com/${social.github}`}>GitHub</a>
+              )}
+              {social.instagram && (
+                <a href={`https://www.instagram.com/${social.instagram}`}>
+                  Instagram
                 </a>
-                <div className="author-introduction">{introduction}</div>
-                <p className="author-socials">
-                  {social.github && (
-                    <a href={`https://github.com/${social.github}`}>GitHub</a>
-                  )}
-                  {social.instagram && (
-                    <a href={`https://www.instagram.com/${social.instagram}`}>
-                      Instagram
-                    </a>
-                  )}
-                  {social.medium && (
-                    <a href={`https://medium.com/${social.medium}`}>Medium</a>
-                  )}
-                  {social.twitter && (
-                    <a href={`https://twitter.com/${social.twitter}`}>
-                      Twitter
-                    </a>
-                  )}
-                  {social.facebook && (
-                    <a href={`https://www.facebook.com/${social.facebook}`}>
-                      Facebook
-                    </a>
-                  )}
-                  {social.linkedin && (
-                    <a href={`https://www.linkedin.com/in/${social.linkedin}/`}>
-                      LinkedIn
-                    </a>
-                  )}
-                </p>
-              </div>
-            </div>
+              )}
+              {social.medium && (
+                <a href={`https://medium.com/${social.medium}`}>Medium</a>
+              )}
+              {social.twitter && (
+                <a href={`https://twitter.com/${social.twitter}`}>Twitter</a>
+              )}
+              {social.facebook && (
+                <a href={`https://www.facebook.com/${social.facebook}`}>
+                  Facebook
+                </a>
+              )}
+              {social.linkedin && (
+                <a href={`https://www.linkedin.com/in/${social.linkedin}/`}>
+                  LinkedIn
+                </a>
+              )}
+            </p>
           </div>
         </div>
-      );
-    }}
-  />
-);
+      </div>
+    </div>
+  );
+};
 
 const bioQuery = graphql`
   query BioQuery {

--- a/src/components/head/index.jsx
+++ b/src/components/head/index.jsx
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 
 export function Seo({
   description,
-  lang,
-  meta,
-  keywords,
+  lang = `en`,
+  meta = [],
+  keywords = [],
   siteMetadata,
-  thumbnail,
+  thumbnail = undefined,
   title,
-  canonicalUrl,
+  canonicalUrl = undefined,
 }) {
   const metaDescription = description || siteMetadata.description;
   const metaTags = [
@@ -84,14 +84,6 @@ export function Seo({
     </>
   );
 }
-
-Seo.defaultProps = {
-  lang: `en`,
-  meta: [],
-  keywords: [],
-  thumbnail: undefined,
-  canonicalUrl: undefined,
-};
 
 Seo.propTypes = {
   description: PropTypes.string,

--- a/src/components/thumbnail-item/index.jsx
+++ b/src/components/thumbnail-item/index.jsx
@@ -19,7 +19,9 @@ export const ThumbnailItem = ({ node, searchQuery }) => (
       <small>{new Date(node.frontmatter.date).toLocaleDateString()}</small>
       <p
         dangerouslySetInnerHTML={{
-          __html: highlightSearchText(node.excerpt, searchQuery),
+          __html: highlightSearchText(node.excerpt, searchQuery, {
+            preserveHtml: true,
+          }),
         }}
       />
     </div>

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -4,7 +4,7 @@ import { graphql } from 'gatsby'
 import { rhythm } from '../utils/typography'
 import * as Lang from '../constants'
 
-export default ({ data }) => {
+const AboutPage = ({ data }) => {
   const resumes = data.allMarkdownRemark.edges
 
   const resume = resumes
@@ -26,6 +26,8 @@ export default ({ data }) => {
     </div>
   )
 }
+
+export default AboutPage
 
 export const pageQuery = graphql`
   query {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,7 +24,7 @@ function getDistance(currentPos) {
   return Dom.getDocumentHeight() - currentPos
 }
 
-export default ({ data, location }) => {
+const HomePage = ({ data, location }) => {
   const initialCount = Storage.getCount(1)
   const initialCategory = Storage.getCategory(CATEGORY_TYPE.ALL)
   const [count, setCount] = useState(initialCount)
@@ -150,6 +150,8 @@ export default ({ data, location }) => {
     </Layout>
   )
 }
+
+export default HomePage
 
 export const Head = ({ data }) => {
   const { siteMetadata } = data.site

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -20,7 +20,7 @@ import * as ScrollManager from '../utils/scroll';
 import '../styles/code.scss';
 import 'katex/dist/katex.min.css';
 
-export default ({ data, pageContext, location }) => {
+const BlogPostTemplate = ({ data, pageContext, location }) => {
   useEffect(() => {
     ScrollManager.init();
     return () => ScrollManager.destroy();
@@ -69,6 +69,8 @@ export default ({ data, pageContext, location }) => {
     </Layout>
   );
 };
+
+export default BlogPostTemplate;
 
 export const Head = ({ data }) => {
   const post = data.markdownRemark;

--- a/src/utils/post-search.js
+++ b/src/utils/post-search.js
@@ -13,6 +13,8 @@ const escapeHtml = value =>
 
 const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
+const HTML_TAG_PATTERN = /(<[^>]+>)/
+
 const getSearchableText = post => {
   const node = post && post.node ? post.node : {}
   const frontmatter = node.frontmatter || {}
@@ -32,12 +34,11 @@ const filterPostsBySearch = (posts, searchQuery) => {
   return posts.filter(post => getSearchableText(post).includes(normalizedQuery))
 }
 
-const highlightSearchText = (value, searchQuery) => {
+const highlightPlainText = (value, normalizedQuery, shouldEscapeHtml) => {
   const text = String(value || '')
-  const normalizedQuery = normalizeSearchText(searchQuery)
 
   if (!normalizedQuery) {
-    return escapeHtml(text)
+    return shouldEscapeHtml ? escapeHtml(text) : text
   }
 
   const matcher = new RegExp(`(${escapeRegExp(normalizedQuery)})`, 'gi')
@@ -45,15 +46,39 @@ const highlightSearchText = (value, searchQuery) => {
   return text
     .split(matcher)
     .map(part => {
-      const escapedPart = escapeHtml(part)
+      const safePart = shouldEscapeHtml ? escapeHtml(part) : part
 
       if (normalizeSearchText(part) === normalizedQuery) {
-        return `<mark class="post-search-highlight">${escapedPart}</mark>`
+        return `<mark class="post-search-highlight">${safePart}</mark>`
       }
 
-      return escapedPart
+      return safePart
     })
     .join('')
+}
+
+const highlightTrustedHtmlText = (value, normalizedQuery) =>
+  String(value || '')
+    .split(HTML_TAG_PATTERN)
+    .map(part => {
+      if (part.startsWith('<') && part.endsWith('>')) {
+        return part
+      }
+
+      return highlightPlainText(part, normalizedQuery, false)
+    })
+    .join('')
+
+const highlightSearchText = (value, searchQuery, options = {}) => {
+  const text = String(value || '')
+  const normalizedQuery = normalizeSearchText(searchQuery)
+  const { preserveHtml = false } = options
+
+  if (preserveHtml) {
+    return highlightTrustedHtmlText(text, normalizedQuery)
+  }
+
+  return highlightPlainText(text, normalizedQuery, true)
 }
 
 const getSearchSummaryText = (resultCount, category, searchQuery) => {

--- a/src/utils/post-search.test.js
+++ b/src/utils/post-search.test.js
@@ -53,6 +53,15 @@ test('leaves text escaped without highlights when search query is blank', () => 
   assert.equal(highlightSearchText('<React>', ''), '&lt;React&gt;')
 })
 
+test('preserves trusted HTML tags while highlighting text content', () => {
+  assert.equal(
+    highlightSearchText('<strong>React</strong> Hooks', 'react', {
+      preserveHtml: true,
+    }),
+    '<strong><mark class="post-search-highlight">React</mark></strong> Hooks'
+  )
+})
+
 test('builds result summary text for category and search state', () => {
   assert.equal(getSearchSummaryText(12, 'All', ''), '전체 포스트 12개')
   assert.equal(


### PR DESCRIPTION
## Summary
- Replace deprecated Gatsby `StaticQuery` usage with `useStaticQuery` and remove function-component `defaultProps`.
- Register `gatsby-plugin-image` and name Gatsby page/template exports to quiet Gatsby development warnings.
- Add an `npm test` script plus GitHub Actions CI for test, lint, and build verification.
- Preserve trusted excerpt HTML when highlighting search matches so existing markup is not flattened.

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
- Browser fresh-load warning check for `StaticQuery`, `defaultProps`, `gatsby-plugin-image`, `Fast Refresh`, and `anonymous` returned no fresh relevant warnings.

## Notes
- The remaining `punycode` deprecation was traced with `NODE_OPTIONS=--trace-deprecation npm run build` to Gatsby transitive dependencies (`whatwg-url` via `node-fetch`, and `@parcel/package-manager`) on local Node 22. CI uses the repo `.nvmrc` Node 20, so this is not app code and does not block the current cleanup.