### PR TITLE
[codex] Add related posts and blog structured data

### DIFF
--- a/src/components/related-posts/index.jsx
+++ b/src/components/related-posts/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Link } from 'gatsby'
+
+import './index.scss'
+
+export const RelatedPosts = ({ posts }) => {
+  if (!posts.length) {
+    return null
+  }
+
+  return (
+    <section className="related-posts" aria-labelledby="related-posts-title">
+      <h2 id="related-posts-title">Related Posts</h2>
+      <ul>
+        {posts.map(({ node }) => (
+          <li key={node.fields.slug}>
+            <Link to={node.fields.slug}>
+              <span>{node.frontmatter.title}</span>
+              <small>
+                {new Date(node.frontmatter.date).toLocaleDateString()}
+              </small>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/related-posts/index.scss
+++ b/src/components/related-posts/index.scss
@@ -1,0 +1,51 @@
+@use '../../styles/variables.scss' as *;
+
+.related-posts {
+  margin: 48px 0 36px;
+
+  h2 {
+    margin-bottom: 12px;
+    font-size: 18px;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li {
+    border-bottom: 0.5px solid #666;
+  }
+
+  a {
+    display: flex;
+    gap: 12px;
+    align-items: baseline;
+    justify-content: space-between;
+    padding: 12px 4px;
+    box-shadow: none;
+  }
+
+  span {
+    line-height: 1.4;
+  }
+
+  small {
+    flex: 0 0 auto;
+    opacity: 0.72;
+  }
+}
+
+@media (max-width: 640px) {
+  .related-posts {
+    a {
+      display: block;
+    }
+
+    small {
+      display: block;
+      margin-top: 4px;
+    }
+  }
+}

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -12,9 +12,14 @@ import { SocialShare } from '../components/social-share';
 import { SponsorButton } from '../components/sponsor-button';
 import { Bio } from '../components/bio';
 import { PostNavigator } from '../components/post-navigator';
+import { RelatedPosts } from '../components/related-posts';
 import { TableOfContents } from '../components/table-of-contents';
 import { Disqus } from '../components/disqus';
 import { Utterences } from '../components/utterances';
+import {
+  buildBlogPostingJsonLd,
+  getRelatedPosts,
+} from '../utils/post-recommendations';
 import * as ScrollManager from '../utils/scroll';
 
 import '../styles/code.scss';
@@ -36,11 +41,16 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
     date,
     thumbnail,
     canonicalUrl,
+    category,
     toc,
   } = post.frontmatter;
   const thumbnailSrc = thumbnail
     ? `${siteUrl}${thumbnail.childImageSharp.gatsbyImageData.images.fallback.src}`
     : undefined;
+  const relatedPosts = getRelatedPosts(data.relatedPosts.edges, {
+    slug,
+    category,
+  });
 
   return (
     <Layout location={location} title={title}>
@@ -56,6 +66,7 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
       )}{' '}
       <Elements.Hr />
       <Bio />
+      <RelatedPosts posts={relatedPosts} />
       <PostNavigator pageContext={pageContext} />{' '}
       {!!disqusShortName && (
         <Disqus
@@ -75,19 +86,38 @@ export default BlogPostTemplate;
 export const Head = ({ data }) => {
   const post = data.markdownRemark;
   const siteMetadata = data.site.siteMetadata;
-  const { title: postTitle, thumbnail, canonicalUrl } = post.frontmatter;
+  const {
+    title: postTitle,
+    isoDate,
+    thumbnail,
+    canonicalUrl,
+  } = post.frontmatter;
   const thumbnailSrc = thumbnail
     ? `${siteMetadata.siteUrl}${thumbnail.childImageSharp.gatsbyImageData.images.fallback.src}`
     : undefined;
+  const postUrl = `${siteMetadata.siteUrl}${post.fields.slug}`;
+  const jsonLd = buildBlogPostingJsonLd({
+    author: siteMetadata.author,
+    canonicalUrl,
+    datePublished: isoDate,
+    description: post.excerpt,
+    image: thumbnailSrc,
+    siteUrl: siteMetadata.siteUrl,
+    title: postTitle,
+    url: postUrl,
+  });
 
   return (
-    <Seo
-      title={postTitle}
-      description={post.excerpt}
-      thumbnail={thumbnailSrc}
-      canonicalUrl={canonicalUrl}
-      siteMetadata={siteMetadata}
-    />
+    <>
+      <Seo
+        title={postTitle}
+        description={post.excerpt}
+        thumbnail={thumbnailSrc}
+        canonicalUrl={canonicalUrl}
+        siteMetadata={siteMetadata}
+      />
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+    </>
   );
 };
 
@@ -111,6 +141,9 @@ export const pageQuery = graphql`
     markdownRemark(fields: { slug: { eq: $slug } }) {
       id
       excerpt(pruneLength: 280)
+      fields {
+        slug
+      }
       html
       headings {
         id
@@ -120,6 +153,8 @@ export const pageQuery = graphql`
       frontmatter {
         title
         date(formatString: "MMMM DD, YYYY")
+        isoDate: date(formatString: "YYYY-MM-DD")
+        category
         toc
         thumbnail {
           childImageSharp {
@@ -127,6 +162,26 @@ export const pageQuery = graphql`
           }
         }
         canonicalUrl
+      }
+    }
+    relatedPosts: allMarkdownRemark(
+      sort: { frontmatter: { date: DESC } }
+      filter: {
+        fields: { slug: { ne: null } }
+        frontmatter: { title: { ne: "" }, category: { ne: null } }
+      }
+    ) {
+      edges {
+        node {
+          fields {
+            slug
+          }
+          frontmatter {
+            title
+            date(formatString: "YYYY-MM-DD")
+            category
+          }
+        }
       }
     }
   }

--- a/src/utils/post-recommendations.js
+++ b/src/utils/post-recommendations.js
@@ -1,0 +1,84 @@
+const toTime = value => {
+  const time = new Date(value).getTime()
+  return Number.isNaN(time) ? 0 : time
+}
+
+const getPostCategory = post =>
+  post && post.node && post.node.frontmatter
+    ? post.node.frontmatter.category
+    : undefined
+
+const getPostSlug = post =>
+  post && post.node && post.node.fields ? post.node.fields.slug : undefined
+
+const sortByNewest = posts =>
+  posts
+    .sort(
+      (firstPost, secondPost) =>
+        toTime(secondPost.node.frontmatter.date) -
+        toTime(firstPost.node.frontmatter.date)
+    )
+
+const getRelatedPosts = (posts, { slug, category, limit = 3 }) => {
+  const candidates = sortByNewest(
+    (posts || []).filter(post => getPostSlug(post) !== slug)
+  )
+  const sameCategoryPosts = candidates.filter(
+    post => getPostCategory(post) === category
+  )
+  const fallbackPosts = candidates.filter(
+    post => getPostCategory(post) !== category
+  )
+
+  return sameCategoryPosts.concat(fallbackPosts).slice(0, limit)
+}
+
+const buildBlogPostingJsonLd = ({
+  author,
+  canonicalUrl,
+  dateModified,
+  datePublished,
+  description,
+  image,
+  siteUrl,
+  title,
+  url,
+}) => {
+  const pageUrl = canonicalUrl || url
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: title,
+    description,
+    datePublished,
+    dateModified: dateModified || datePublished,
+    author: {
+      '@type': 'Person',
+      name: author,
+    },
+    publisher: {
+      '@type': 'Person',
+      name: author,
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': pageUrl,
+    },
+    url: pageUrl,
+    isPartOf: {
+      '@type': 'Blog',
+      url: siteUrl,
+    },
+  }
+
+  if (image) {
+    jsonLd.image = [image]
+  }
+
+  return jsonLd
+}
+
+module.exports = {
+  buildBlogPostingJsonLd,
+  getRelatedPosts,
+}

--- a/src/utils/post-recommendations.test.js
+++ b/src/utils/post-recommendations.test.js
@@ -1,0 +1,136 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  buildBlogPostingJsonLd,
+  getRelatedPosts,
+} = require('./post-recommendations')
+
+const createPost = ({ slug, title, category, date }) => ({
+  node: {
+    fields: { slug },
+    excerpt: `${title} excerpt`,
+    frontmatter: {
+      title,
+      category,
+      date,
+    },
+  },
+})
+
+test('returns latest related posts from the same category excluding the current post', () => {
+  const posts = [
+    createPost({
+      slug: '/react/current/',
+      title: 'Current React Post',
+      category: 'React',
+      date: '2026-06-01',
+    }),
+    createPost({
+      slug: '/react/newest/',
+      title: 'Newest React Post',
+      category: 'React',
+      date: '2026-06-20',
+    }),
+    createPost({
+      slug: '/react/older/',
+      title: 'Older React Post',
+      category: 'React',
+      date: '2026-05-10',
+    }),
+    createPost({
+      slug: '/javascript/other/',
+      title: 'Other Category Post',
+      category: 'JavaScript',
+      date: '2026-06-25',
+    }),
+  ]
+
+  assert.deepEqual(
+    getRelatedPosts(posts, {
+      slug: '/react/current/',
+      category: 'React',
+      limit: 2,
+    }).map(post => post.node.fields.slug),
+    ['/react/newest/', '/react/older/']
+  )
+})
+
+test('fills related posts with latest posts when the same category has fewer matches', () => {
+  const posts = [
+    createPost({
+      slug: '/react/current/',
+      title: 'Current React Post',
+      category: 'React',
+      date: '2026-06-01',
+    }),
+    createPost({
+      slug: '/react/related/',
+      title: 'Related React Post',
+      category: 'React',
+      date: '2026-06-20',
+    }),
+    createPost({
+      slug: '/javascript/latest/',
+      title: 'Latest JavaScript Post',
+      category: 'JavaScript',
+      date: '2026-06-25',
+    }),
+    createPost({
+      slug: '/web/older/',
+      title: 'Older Web Post',
+      category: 'Web',
+      date: '2026-05-10',
+    }),
+  ]
+
+  assert.deepEqual(
+    getRelatedPosts(posts, {
+      slug: '/react/current/',
+      category: 'React',
+      limit: 3,
+    }).map(post => post.node.fields.slug),
+    ['/react/related/', '/javascript/latest/', '/web/older/']
+  )
+})
+
+test('builds BlogPosting JSON-LD for a post', () => {
+  assert.deepEqual(
+    buildBlogPostingJsonLd({
+      author: 'ykss',
+      canonicalUrl: 'https://ykss.netlify.app/custom-canonical/',
+      datePublished: '2026-06-29',
+      description: 'Structured data excerpt',
+      image: 'https://ykss.netlify.app/thumbnail.png',
+      siteUrl: 'https://ykss.netlify.app',
+      title: 'Structured Data Post',
+      url: 'https://ykss.netlify.app/posts/structured-data/',
+    }),
+    {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: 'Structured Data Post',
+      description: 'Structured data excerpt',
+      image: ['https://ykss.netlify.app/thumbnail.png'],
+      datePublished: '2026-06-29',
+      dateModified: '2026-06-29',
+      author: {
+        '@type': 'Person',
+        name: 'ykss',
+      },
+      publisher: {
+        '@type': 'Person',
+        name: 'ykss',
+      },
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': 'https://ykss.netlify.app/custom-canonical/',
+      },
+      url: 'https://ykss.netlify.app/custom-canonical/',
+      isPartOf: {
+        '@type': 'Blog',
+        url: 'https://ykss.netlify.app',
+      },
+    }
+  )
+})


### PR DESCRIPTION
## Summary
- Add a `Related Posts` section below each blog post.
- Recommend same-category posts first, then fill remaining slots with recent posts.
- Add `BlogPosting` JSON-LD structured data to post pages.
- Cover recommendation and JSON-LD generation with node test cases.

## Validation
- `npm test` - 10/10 passed
- `npm run lint`
- `npm run build`
- Confirmed generated HTML includes `application/ld+json`, `BlogPosting`, and `Related Posts` for a sample post page.

## Notes
- Local `git push` is unavailable in this environment because HTTPS GitHub auth is not configured, so the branch was published through the GitHub connector using the same tree as local HEAD.