### PR TITLE
[codex] Improve post reading experience

### DIFF
--- a/src/components/post-container/index.jsx
+++ b/src/components/post-container/index.jsx
@@ -1,5 +1,220 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
-export const PostContainer = ({ html }) => (
-  <div dangerouslySetInnerHTML={{ __html: html }} />
-)
+import { getReadingProgressStorageKey } from '../../utils/post-reading'
+
+import './index.scss'
+
+const ENHANCED_CODE_CLASS_NAME = 'post-code-block--enhanced'
+
+const getCodeLanguage = pre => {
+  const code = pre.querySelector('code[class*="language-"]')
+  const languageClass =
+    code &&
+    Array.from(code.classList).find(className =>
+      className.indexOf('language-') === 0
+    )
+
+  return languageClass ? languageClass.replace('language-', '') : 'code'
+}
+
+const copyText = async text => {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch (error) {
+      // Fall back below for HTTP/static preview environments.
+    }
+  }
+
+  const textarea = document.createElement('textarea')
+
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.top = '-9999px'
+  document.body.appendChild(textarea)
+  textarea.select()
+
+  const didCopy = document.execCommand('copy')
+  document.body.removeChild(textarea)
+
+  if (!didCopy) {
+    throw new Error('Copy command failed')
+  }
+}
+
+const selectCodeText = pre => {
+  const code = pre.querySelector('code') || pre
+  const selection = window.getSelection()
+  const range = document.createRange()
+
+  range.selectNodeContents(code)
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
+const enhanceCodeBlocks = container => {
+  const cleanupHandlers = []
+
+  container.querySelectorAll('pre[class*="language-"]').forEach(pre => {
+    if (pre.classList.contains(ENHANCED_CODE_CLASS_NAME)) {
+      return
+    }
+
+    pre.classList.add(ENHANCED_CODE_CLASS_NAME)
+
+    const header = document.createElement('div')
+    const label = document.createElement('span')
+    const button = document.createElement('button')
+
+    header.className = 'post-code-block__header'
+    label.className = 'post-code-block__language'
+    label.textContent = getCodeLanguage(pre)
+    button.className = 'post-code-block__copy'
+    button.type = 'button'
+    button.textContent = 'Copy'
+
+    const handleCopy = async () => {
+      const code = pre.querySelector('code')
+      const text = code ? code.textContent : pre.textContent
+
+      try {
+        await copyText(text)
+        button.textContent = 'Copied'
+        window.setTimeout(() => {
+          button.textContent = 'Copy'
+        }, 1500)
+      } catch (error) {
+        selectCodeText(pre)
+        button.textContent = 'Selected'
+      }
+    }
+
+    button.addEventListener('click', handleCopy)
+    cleanupHandlers.push(() => button.removeEventListener('click', handleCopy))
+
+    header.appendChild(label)
+    header.appendChild(button)
+    pre.parentNode.insertBefore(header, pre)
+  })
+
+  return () => cleanupHandlers.forEach(cleanup => cleanup())
+}
+
+const enhanceHeadingAnchors = container => {
+  container.querySelectorAll('h2[id], h3[id]').forEach(heading => {
+    if (heading.querySelector('.post-heading-anchor')) {
+      return
+    }
+
+    const anchor = document.createElement('a')
+    anchor.className = 'post-heading-anchor'
+    anchor.href = `#${heading.id}`
+    anchor.setAttribute('aria-label', `${heading.textContent} 섹션 링크`)
+    anchor.textContent = '#'
+    heading.appendChild(anchor)
+  })
+}
+
+export const PostContainer = ({ html, slug }) => {
+  const containerRef = useRef(null)
+  const [lightboxImage, setLightboxImage] = useState(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+
+    if (!container) {
+      return undefined
+    }
+
+    const cleanupCodeBlocks = enhanceCodeBlocks(container)
+    enhanceHeadingAnchors(container)
+
+    return cleanupCodeBlocks
+  }, [html])
+
+  useEffect(() => {
+    const container = containerRef.current
+
+    if (!container) {
+      return undefined
+    }
+
+    const handleImageClick = event => {
+      const image = event.target.closest('img')
+
+      if (!image || !container.contains(image)) {
+        return
+      }
+
+      setLightboxImage({
+        alt: image.getAttribute('alt') || '',
+        src: image.currentSrc || image.getAttribute('src'),
+      })
+    }
+
+    container.addEventListener('click', handleImageClick)
+
+    return () => container.removeEventListener('click', handleImageClick)
+  }, [])
+
+  useEffect(() => {
+    if (!slug || typeof window === 'undefined') {
+      return undefined
+    }
+
+    const storageKey = getReadingProgressStorageKey(slug)
+    const savedPosition = Number(window.sessionStorage.getItem(storageKey) || 0)
+
+    if (!window.location.hash && savedPosition > 120) {
+      window.setTimeout(() => {
+        window.scrollTo({ top: savedPosition, behavior: 'auto' })
+      }, 80)
+    }
+
+    let animationFrame = null
+
+    const savePosition = () => {
+      if (animationFrame) {
+        return
+      }
+
+      animationFrame = window.requestAnimationFrame(() => {
+        window.sessionStorage.setItem(storageKey, String(Math.round(window.scrollY)))
+        animationFrame = null
+      })
+    }
+
+    window.addEventListener('scroll', savePosition, { passive: true })
+
+    return () => {
+      window.removeEventListener('scroll', savePosition)
+
+      if (animationFrame) {
+        window.cancelAnimationFrame(animationFrame)
+      }
+    }
+  }, [slug])
+
+  return (
+    <>
+      <article
+        id="post-content"
+        className="post-content"
+        ref={containerRef}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      {lightboxImage && (
+        <button
+          className="post-image-lightbox"
+          type="button"
+          onClick={() => setLightboxImage(null)}
+          aria-label="이미지 닫기"
+        >
+          <img src={lightboxImage.src} alt={lightboxImage.alt} />
+        </button>
+      )}
+    </>
+  )
+}

--- a/src/components/post-container/index.scss
+++ b/src/components/post-container/index.scss
@@ -1,0 +1,81 @@
+.post-content {
+  h2,
+  h3 {
+    scroll-margin-top: 5rem;
+  }
+
+  img {
+    cursor: zoom-in;
+  }
+}
+
+.post-heading-anchor {
+  margin-left: 0.4rem;
+  box-shadow: none;
+  font-size: 0.75em;
+  opacity: 0;
+  text-decoration: none;
+  transition: opacity 0.2s;
+}
+
+h2:hover .post-heading-anchor,
+h3:hover .post-heading-anchor,
+.post-heading-anchor:focus {
+  opacity: 0.58;
+}
+
+.post-code-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 1.5em 0 -1.5em;
+  padding: 0.55rem 0.8rem;
+  border-radius: 0.6em 0.6em 0 0;
+  background: #191919;
+  color: #d8d8d8;
+  font-size: 0.72rem;
+}
+
+.post-code-block__language {
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.post-code-block__copy {
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  opacity: 0.75;
+}
+
+.post-code-block__copy:hover,
+.post-code-block__copy:focus {
+  opacity: 1;
+}
+
+.post-code-block__header + pre[class*='language-'] {
+  border-radius: 0 0 0.6em 0.6em;
+}
+
+.post-image-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  border: 0;
+  background: rgba(0, 0, 0, 0.82);
+  cursor: zoom-out;
+
+  img {
+    max-width: min(100%, 960px);
+    max-height: 88vh;
+    object-fit: contain;
+  }
+}

--- a/src/components/post-footer-actions/index.jsx
+++ b/src/components/post-footer-actions/index.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import { Bio } from '../bio'
+import { PostNavigator } from '../post-navigator'
+import { RelatedPosts } from '../related-posts'
+
+import './index.scss'
+
+export const PostFooterActions = ({ hasComments, pageContext, relatedPosts }) => (
+  <section className="post-footer-actions" aria-label="Post actions">
+    <RelatedPosts posts={relatedPosts} />
+    <PostNavigator pageContext={pageContext} />
+    <Bio />
+    {hasComments && (
+      <div className="post-footer-actions__comments">
+        <a href="#post-comments">댓글로 이동</a>
+      </div>
+    )}
+  </section>
+)

--- a/src/components/post-footer-actions/index.scss
+++ b/src/components/post-footer-actions/index.scss
@@ -1,0 +1,18 @@
+.post-footer-actions {
+  margin: 2.5rem 0 1.5rem;
+}
+
+.post-footer-actions__comments {
+  margin-top: 1.5rem;
+  text-align: center;
+
+  a {
+    display: inline-block;
+    padding: 0.55rem 0.9rem;
+    border: 1px solid currentColor;
+    border-radius: 6px;
+    box-shadow: none;
+    font-size: 0.85rem;
+    opacity: 0.82;
+  }
+}

--- a/src/components/post-meta/index.jsx
+++ b/src/components/post-meta/index.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import './index.scss'
+
+export const PostMeta = ({ date, readingTimeText, hasComments }) => (
+  <div className="post-meta">
+    <span>{date}</span>
+    {readingTimeText && <span>{readingTimeText}</span>}
+    {hasComments && (
+      <a className="post-meta__comments" href="#post-comments">
+        댓글로 이동
+      </a>
+    )}
+  </div>
+)

--- a/src/components/post-meta/index.scss
+++ b/src/components/post-meta/index.scss
@@ -1,0 +1,21 @@
+.post-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.75rem;
+  align-items: center;
+  margin: 0.5rem 0 1.7rem;
+  font-size: 0.88rem;
+  opacity: 0.78;
+
+  span:not(:last-child)::after {
+    content: '';
+  }
+
+  a {
+    box-shadow: none;
+  }
+}
+
+.post-meta__comments {
+  border-bottom: 1px solid currentColor;
+}

--- a/src/components/post-navigator/index.jsx
+++ b/src/components/post-navigator/index.jsx
@@ -7,21 +7,23 @@ export const PostNavigator = ({ pageContext }) => {
   const { previous, next } = pageContext
 
   return (
-    <ul className="navigator">
-      <li>
+    <nav className="navigator" aria-label="Previous and next posts">
+      <div className="navigator__item">
         {previous && (
-          <Link to={previous.fields.slug} rel="prev">
-            ← {previous.frontmatter.title}
+          <Link className="navigator__link" to={previous.fields.slug} rel="prev">
+            <small>Previous</small>
+            <span>{previous.frontmatter.title}</span>
           </Link>
         )}
-      </li>
-      <li>
+      </div>
+      <div className="navigator__item">
         {next && (
-          <Link to={next.fields.slug} rel="next">
-            {next.frontmatter.title} →
+          <Link className="navigator__link" to={next.fields.slug} rel="next">
+            <small>Next</small>
+            <span>{next.frontmatter.title}</span>
           </Link>
         )}
-      </li>
-    </ul>
+      </div>
+    </nav>
   )
 }

--- a/src/components/post-navigator/index.scss
+++ b/src/components/post-navigator/index.scss
@@ -2,20 +2,44 @@
 
 .navigator {
   margin: 40px 0;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
   list-style: none;
   padding: 0;
 
-  li {
-    margin-bottom: 12px;
+  .navigator__item {
+    display: block;
+    min-width: 0;
   }
 
   a {
-    padding: 7px 16px 8px 16px;
+    display: block;
+    min-height: 100%;
+    padding: 12px 14px;
+    border: 1px solid rgba(102, 102, 102, 0.45);
     border-radius: 6px;
-    font-size: 12px;
+    box-shadow: none;
     opacity: 0.8;
+  }
+
+  small {
+    display: block;
+    margin-bottom: 4px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+  }
+
+  span {
+    display: block;
+    line-height: 1.4;
+  }
+}
+
+@media (max-width: 640px) {
+  .navigator {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/components/table-of-contents/index.jsx
+++ b/src/components/table-of-contents/index.jsx
@@ -35,6 +35,7 @@ const TocLinks = ({ headings, activeId }) => (
 export const TableOfContents = ({ headings }) => {
   const [activeId, setActiveId] = useState('')
   const tocHeadings = useMemo(() => getVisibleHeadings(headings), [headings])
+  const activeHeading = tocHeadings.find(heading => heading.id === activeId)
 
   useEffect(() => {
     if (!tocHeadings.length) {
@@ -117,6 +118,12 @@ export const TableOfContents = ({ headings }) => {
 
     window.history.replaceState(null, '', href)
     setActiveId(target.id)
+
+    const mobileToc = event.currentTarget.closest('details')
+
+    if (mobileToc) {
+      mobileToc.open = false
+    }
   }
 
   if (tocHeadings.length < MIN_HEADING_COUNT) {
@@ -134,7 +141,14 @@ export const TableOfContents = ({ headings }) => {
         <TocLinks headings={tocHeadings} activeId={activeId} />
       </nav>
       <details className="table-of-contents table-of-contents--mobile">
-        <summary className="table-of-contents__summary">Contents</summary>
+        <summary className="table-of-contents__summary">
+          <span>Contents</span>
+          {activeHeading && (
+            <span className="table-of-contents__current">
+              {activeHeading.value}
+            </span>
+          )}
+        </summary>
         <nav aria-label="Table of contents" onClick={handleClick}>
           <TocLinks headings={tocHeadings} activeId={activeId} />
         </nav>

--- a/src/components/table-of-contents/index.scss
+++ b/src/components/table-of-contents/index.scss
@@ -77,15 +77,33 @@
   border-radius: 6px;
   margin: 1.5rem 0 2rem;
   padding: 0.8rem 0.95rem;
+  position: sticky;
+  top: 0.75rem;
+  z-index: 3;
 
   .table-of-contents__summary {
     cursor: pointer;
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+    justify-content: space-between;
     margin-bottom: 0;
   }
 
   &[open] .table-of-contents__summary {
     margin-bottom: 0.65rem;
   }
+}
+
+.table-of-contents__current {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.68rem;
+  font-weight: 400;
+  opacity: 0.64;
+  text-overflow: ellipsis;
+  text-transform: none;
+  white-space: nowrap;
 }
 
 @media (min-width: 1280px) {

--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -71,6 +71,8 @@ pre[class*='language-'] {
   padding: 0.1em 0.6em;
   border-radius: 0.2em;
   white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   background: $inline-dimmed-color;
   color: $inline-text-color;
 }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -5,14 +5,12 @@ import * as Elements from '../components/elements';
 import { Layout } from '../layout';
 import { Seo } from '../components/head';
 import { PostTitle } from '../components/post-title';
-import { PostDate } from '../components/post-date';
+import { PostMeta } from '../components/post-meta';
 import { PostContainer } from '../components/post-container';
 import { ScrollIndicator } from '../components/scroll-indicator';
 import { SocialShare } from '../components/social-share';
 import { SponsorButton } from '../components/sponsor-button';
-import { Bio } from '../components/bio';
-import { PostNavigator } from '../components/post-navigator';
-import { RelatedPosts } from '../components/related-posts';
+import { PostFooterActions } from '../components/post-footer-actions';
 import { TableOfContents } from '../components/table-of-contents';
 import { Disqus } from '../components/disqus';
 import { Utterences } from '../components/utterances';
@@ -20,6 +18,7 @@ import {
   buildBlogPostingJsonLd,
   getRelatedPosts,
 } from '../utils/post-recommendations';
+import { getPostReadingMeta } from '../utils/post-reading';
 import * as ScrollManager from '../utils/scroll';
 
 import '../styles/code.scss';
@@ -36,6 +35,7 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
   const slug = pageContext.slug;
   const { title, comment, siteUrl, author, sponsor } = metaData;
   const { disqusShortName, utterances } = comment;
+  const hasComments = !!disqusShortName || !!utterances;
   const {
     title: postTitle,
     date,
@@ -51,32 +51,43 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
     slug,
     category,
   });
+  const { readingTimeText } = getPostReadingMeta({
+    wordCount: post.wordCount.words,
+  });
 
   return (
     <Layout location={location} title={title}>
       <ScrollIndicator />
       <PostTitle title={postTitle} />
-      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-        <PostDate date={date} />
-      </div>
+      <PostMeta
+        date={date}
+        readingTimeText={readingTimeText}
+        hasComments={hasComments}
+      />
       {toc !== false && <TableOfContents headings={post.headings} />}
-      <PostContainer html={post.html} />{' '}
+      <PostContainer html={post.html} slug={slug} />{' '}
       {!!sponsor.buyMeACoffeeId && (
         <SponsorButton sponsorId={sponsor.buyMeACoffeeId} />
       )}{' '}
       <Elements.Hr />
-      <Bio />
-      <RelatedPosts posts={relatedPosts} />
-      <PostNavigator pageContext={pageContext} />{' '}
-      {!!disqusShortName && (
-        <Disqus
-          post={post}
-          shortName={disqusShortName}
-          siteUrl={siteUrl}
-          slug={pageContext.slug}
-        />
-      )}{' '}
-      {!!utterances && <Utterences repo={utterances} />}{' '}
+      <PostFooterActions
+        hasComments={hasComments}
+        pageContext={pageContext}
+        relatedPosts={relatedPosts}
+      />
+      {hasComments && (
+        <section id="post-comments" className="post-comments">
+          {!!disqusShortName && (
+            <Disqus
+              post={post}
+              shortName={disqusShortName}
+              siteUrl={siteUrl}
+              slug={pageContext.slug}
+            />
+          )}{' '}
+          {!!utterances && <Utterences repo={utterances} />}{' '}
+        </section>
+      )}
     </Layout>
   );
 };
@@ -141,6 +152,9 @@ export const pageQuery = graphql`
     markdownRemark(fields: { slug: { eq: $slug } }) {
       id
       excerpt(pruneLength: 280)
+      wordCount {
+        words
+      }
       fields {
         slug
       }

--- a/src/utils/post-reading.js
+++ b/src/utils/post-reading.js
@@ -1,0 +1,18 @@
+const WORDS_PER_MINUTE = 230
+const READING_PROGRESS_PREFIX = 'post-reading-progress:'
+
+const getPostReadingMeta = ({ wordCount }) => {
+  const minutes = Math.max(1, Math.ceil(Number(wordCount || 0) / WORDS_PER_MINUTE))
+
+  return {
+    readingTimeText: `약 ${minutes}분 읽기`,
+  }
+}
+
+const getReadingProgressStorageKey = slug =>
+  `${READING_PROGRESS_PREFIX}${slug || 'unknown'}`
+
+module.exports = {
+  getPostReadingMeta,
+  getReadingProgressStorageKey,
+}

--- a/src/utils/post-reading.test.js
+++ b/src/utils/post-reading.test.js
@@ -1,0 +1,26 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  getPostReadingMeta,
+  getReadingProgressStorageKey,
+} = require('./post-reading')
+
+test('builds post reading meta from word count', () => {
+  assert.deepEqual(getPostReadingMeta({ wordCount: 820 }), {
+    readingTimeText: '약 4분 읽기',
+  })
+})
+
+test('uses at least one minute for short posts', () => {
+  assert.deepEqual(getPostReadingMeta({ wordCount: 40 }), {
+    readingTimeText: '약 1분 읽기',
+  })
+})
+
+test('builds a stable reading progress key from slug', () => {
+  assert.equal(
+    getReadingProgressStorageKey('/translation/2026/example-post/'),
+    'post-reading-progress:/translation/2026/example-post/'
+  )
+})


### PR DESCRIPTION
## Summary
- Add post reading metadata, including estimated reading time and comment jump links.
- Improve the post reading surface with mobile TOC behavior, heading anchors, image lightbox, code block actions, and reading position restore.
- Refresh previous/next navigation and consolidate bottom post actions.

## Validation
- `npm test` passed: 13/13
- `npm run lint` passed
- `npm run build` passed
- Browser QA against the static production build confirmed mobile overflow is fixed, code block controls render, heading anchors render, image lightbox opens, and comment jump works.

## Notes
- Gatsby still prints the existing `punycode` deprecation warning during build, but the build exits successfully.